### PR TITLE
Preserve default values of entity

### DIFF
--- a/src/FactoryGirl/Provider/Doctrine/EntityDef.php
+++ b/src/FactoryGirl/Provider/Doctrine/EntityDef.php
@@ -48,10 +48,20 @@ class EntityDef
     }
     
     private function defaultDefsFromMetadata() {
+
+        $defaultEntity = $this->getEntityMetadata()->newInstance();
+
         $allFields = array_merge($this->metadata->getFieldNames(), $this->metadata->getAssociationNames());
         foreach ($allFields as $fieldName) {
             if (!isset($this->fieldDefs[$fieldName])) {
-                $this->fieldDefs[$fieldName] = function() { return null; };
+
+                $defaultFieldValue = $this->metadata->getFieldValue($defaultEntity, $fieldName);
+
+                if($defaultFieldValue !== null) {
+                    $this->fieldDefs[$fieldName] = function() use ($defaultFieldValue) { return $defaultFieldValue; };
+                } else {
+                    $this->fieldDefs[$fieldName] = function() { return null; };
+                }
             }
         }
     }

--- a/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
+++ b/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
@@ -47,6 +47,17 @@ class BasicUsageTest extends TestCase
             ->get('SpaceShip', array('name' => 'My CattleBruiser'));
         $this->assertEquals('My CattleBruiser', $ss->getName());
     }
+
+    /**
+     * @test
+     */
+    public function preservesDefaultValuesOfEntity()
+    {
+        $ss = $this->factory
+            ->defineEntity('SpaceStation')
+            ->get('SpaceStation');
+        $this->assertEquals('Babylon5', $ss->getName());
+    }    
     
     /**
      * @test

--- a/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/TestEntity/SpaceStation.php
+++ b/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/TestEntity/SpaceStation.php
@@ -1,0 +1,40 @@
+<?php
+namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity;
+
+use Doctrine\Common\Collections\ArrayCollection;
+
+/**
+ * @Entity
+ */
+class SpaceStation
+{
+    /**
+     * @Id
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(type="integer")
+     */
+    protected $id;
+    
+    /** @Column */
+    protected $name = 'Babylon5';
+    
+    public function __construct($name)
+    {
+        $this->name = $name;
+    }
+    
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+    
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}


### PR DESCRIPTION
If a default value is specified for a given field in an entity,
the EntityDefinition will now keep this value and will not set
it to null.

If no default value is specified, the field value will still
be set to null.
