### PR TITLE
add getList method to get list of entities

### DIFF
--- a/src/FactoryGirl/Provider/Doctrine/FixtureFactory.php
+++ b/src/FactoryGirl/Provider/Doctrine/FixtureFactory.php
@@ -108,7 +108,30 @@ class FixtureFactory
         
         return $ent;
     }
-    
+
+
+    /**
+     * Get an array of entities and their dependencies.
+     *
+     * Whether the entities are new or not depends on whether you've created
+     * a singleton with the entity name. See `getAsSingleton()`.
+     *
+     * If you've called `persistOnGet()` then the entities are also persisted.
+     */
+    public function getList($name, array $fieldOverrides = array(), $numberOfInstances = 1)
+    {
+        if ($numberOfInstances < 1) {
+            throw new \InvalidArgumentException('Can only get >= 1 instances');
+        }
+
+        $instances = array();
+        for ($i = 0; $i < $numberOfInstances; $i++) {
+            $instances[] = $this->get($name, $fieldOverrides);
+        }
+
+        return $instances;
+    }
+
     protected function checkFieldOverrides(EntityDef $def, array $fieldOverrides)
     {
         $extraFields = array_diff(array_keys($fieldOverrides), array_keys($def->getFieldDefs()));

--- a/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
+++ b/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
@@ -152,4 +152,24 @@ class BasicUsageTest extends TestCase
             ))
         );
     }
+
+    /**
+     * @test
+     */
+    public function returnsListOfEntities()
+    {
+        $this->factory->defineEntity('SpaceShip');
+
+        $this->assertCount(1, $this->factory->getList('SpaceShip'));
+    }
+
+    /**
+     * @test
+     */
+    public function canSpecifyNumberOfReturnedInstances()
+    {
+        $this->factory->defineEntity('SpaceShip');
+
+        $this->assertCount(5, $this->factory->getList('SpaceShip', array(), 5));
+    }
 }

--- a/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/tests/FactoryGirl/Tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -65,4 +65,17 @@ class IncorrectUsageTest extends TestCase
             ));
         });
     }
+
+    /**
+     * @test
+     */
+    public function throwsWhenTryingToGetLessThanOneInstance()
+    {
+        $this->factory->defineEntity('SpaceShip');
+
+        $self = $this;
+        $this->assertThrows(function() use ($self) {
+            $self->factory->getList('SpaceShip', array(), 0);
+        });
+    }
 }


### PR DESCRIPTION
Adds a `getList` method to the `FixtureFactory` to get an Array of Entities. Would close #11.

Btw, it took me a few minutes to figure out I need to do a `composer install --prefer-source` to be able to run the tests. Maybe we should add a hint about that in the Readme.
