### PR TITLE
Fix: Remove invalid autoload mapping

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,8 +31,7 @@
     },
     "autoload-dev": {
         "psr-0": {
-            "FactoryGirl\\Tests": "tests",
-            "Doctrine\\Tests": "vendor/doctrine/dbal/tests"
+            "FactoryGirl\\Tests": "tests"
         }
     }
 }


### PR DESCRIPTION
This PR

* [x] removes an invalid autoload mapping

💁‍♂️ For reference, see [`.gitattributes`](https://github.com/doctrine/dbal/blob/v2.5.2/.gitattributes#L1) of [`doctrine/dbal`](https://github.com/doctrine/dbal/tree/v2.5.2.).