### PR TITLE
Fix: Cache dependencies installed with composer between builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ branches:
   only:
   - master
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 install: composer install
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,9 @@
             "email": "breerly@gmail.com"
         }
     ],
+    "config": {
+        "preferred-install": "dist"
+    },
     "require": {
         "php": ">=5.4.0",
         "doctrine/orm": ">=2.2.1,<2.6-dev",


### PR DESCRIPTION
This PR

* [x] caches dependencies installed with `composer` between Travis builds