### PR TITLE
Fix: Do not self-update composer twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ branches:
   only:
   - master
 
-before_install: composer self-update
-
 install: composer install
 
 script:


### PR DESCRIPTION
This PR

* [x] removes a redundant update of `composer` itself

💁‍♂️ There was a period where Travis wouldn't update `composer` itself to the latest version, but that time has passed. Good to shave of critical milliseconds, hehe!