### PR TITLE
Enhancement: Suggest usage of fzaninotto/faker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,9 @@
     "require-dev": {
         "phpunit/phpunit": "4.5.0"
     },
+    "suggest": {
+        "fzaninotto/faker": "For generating fake data in entity definitions"
+    },
     "autoload": {
         "psr-4": {
             "FactoryGirl\\": "src/"


### PR DESCRIPTION
This PR

* [x] suggests to use `fzaninotto/faker` for generating fake data in entity definitions

💁‍♂️ Does that make sense?