### PR TITLE
Fix: Reject invalid values from DateIntervalHelper

### DIFF
--- a/src/Provider/Doctrine/DateIntervalHelper.php
+++ b/src/Provider/Doctrine/DateIntervalHelper.php
@@ -32,13 +32,12 @@ class DateIntervalHelper
 
     /**
      * @param int $years
+     * @throws \InvalidArgumentException
      * @return $this
      */
     public function years($years)
     {
-        if (!is_numeric($years) || $years != (int) $years) {
-            throw new \RuntimeException();
-        }
+        $this->assertIntegerish($years);
 
         $this->modify(new \DateInterval('P'.$years.'Y'));
         
@@ -47,13 +46,12 @@ class DateIntervalHelper
 
     /**
      * @param int $months
+     * @throws \InvalidArgumentException
      * @return $this
      */
     public function months($months)
     {
-        if (!is_numeric($months) || $months != (int) $months) {
-            throw new \RuntimeException();
-        }
+        $this->assertIntegerish($months);
 
         $this->modify(new \DateInterval('P'.$months.'M'));
         
@@ -62,14 +60,13 @@ class DateIntervalHelper
 
     /**
      * @param int $days
+     * @throws \InvalidArgumentException
      * @return $this
      */
     public function days($days)
     {
-        if (!is_numeric($days) || $days != (int) $days) {
-            throw new \RuntimeException();
-        }
-        
+        $this->assertIntegerish($days);
+
         $this->modify(new \DateInterval('P'.$days.'D'));
         
         return $this;
@@ -101,6 +98,20 @@ class DateIntervalHelper
         } 
 
         throw new \InvalidArgumentException("Unknown time format '". $format ."'");
+    }
+
+    /**
+     * @param mixed $value
+     * @throws \InvalidArgumentException
+     */
+    private function assertIntegerish($value)
+    {
+        if (!is_numeric($value) || $value != (int)$value) {
+            throw new \InvalidArgumentException(sprintf(
+                'Expected integer or integerish string, got "%s" instead.',
+                is_object($value) ? get_class($value) : gettype($value)
+            ));
+        }
     }
 
 }

--- a/src/Provider/Doctrine/DateIntervalHelper.php
+++ b/src/Provider/Doctrine/DateIntervalHelper.php
@@ -36,7 +36,7 @@ class DateIntervalHelper
      */
     public function years($years)
     {
-        if (!is_numeric($years)) {
+        if (!is_numeric($years) || $years != (int) $years) {
             throw new \RuntimeException();
         }
 
@@ -51,7 +51,7 @@ class DateIntervalHelper
      */
     public function months($months)
     {
-        if (!is_numeric($months)) {
+        if (!is_numeric($months) || $months != (int) $months) {
             throw new \RuntimeException();
         }
 
@@ -66,7 +66,7 @@ class DateIntervalHelper
      */
     public function days($days)
     {
-        if (!is_numeric($days)) {
+        if (!is_numeric($days) || $days != (int) $days) {
             throw new \RuntimeException();
         }
         

--- a/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
+++ b/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace FactoryGirl\Tests\Provider\Doctrine\ORM;
+
+use FactoryGirl\Provider\Doctrine\DateIntervalHelper;
+
+class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider providerInvalidIntegerish
+     * 
+     * @param mixed $years
+     */
+    public function testYearsRejectsInvalidValue($years)
+    {
+        $helper = new DateIntervalHelper(new \DateTime());
+        
+        $this->setExpectedException('RuntimeException');
+        
+        $helper->years($years);
+    }
+
+    /**
+     * @dataProvider providerInvalidIntegerish
+     * 
+     * @param mixed $months
+     */
+    public function testMonthsRejectsInvalidValue($months)
+    {
+        $helper = new DateIntervalHelper(new \DateTime());
+        
+        $this->setExpectedException('RuntimeException');
+        
+        $helper->months($months);
+    }
+
+    /**
+     * @dataProvider providerInvalidIntegerish
+     * 
+     * @param mixed $days
+     */
+    public function testDaysRejectsInvalidValue($days)
+    {
+        $helper = new DateIntervalHelper(new \DateTime());
+        
+        $this->setExpectedException('RuntimeException');
+        
+        $helper->days($days);
+    }
+
+    /**
+     * @return array
+     */
+    public function providerInvalidIntegerish()
+    {
+        $values = [
+            'array' => [],
+            'boolean-false' => false,
+            'boolean-true' => true,
+            'float-negative' => -3.14,
+            'float-negative-casted-to-string' => (string) -3.14,
+            'float-positive' => 3.14,
+            'float-positive-casted-to-string' => (string) 3.14,
+            'null' => null,
+            'object' => new \stdClass(),
+            'resource' => fopen(__FILE__, 'r'),
+            'string' => 'foo',
+        ];
+        
+        return \array_map(function ($value) {
+            return [
+                $value,
+            ];
+        }, $values);
+    }
+}

--- a/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
+++ b/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
@@ -15,7 +15,10 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('RuntimeException');
+        $this->setExpectedException('InvalidArgumentException', sprintf(
+            'Expected integer or integerish string, got "%s" instead.',
+            is_object($years) ? get_class($years) : gettype($years)
+        ));
         
         $helper->years($years);
     }
@@ -29,8 +32,11 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('RuntimeException');
-        
+        $this->setExpectedException('InvalidArgumentException', sprintf(
+            'Expected integer or integerish string, got "%s" instead.',
+            is_object($months) ? get_class($months) : gettype($months)
+        ));
+
         $helper->months($months);
     }
 
@@ -43,7 +49,10 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('RuntimeException');
+        $this->setExpectedException('InvalidArgumentException', sprintf(
+            'Expected integer or integerish string, got "%s" instead.',
+            is_object($days) ? get_class($days) : gettype($days)
+        ));
         
         $helper->days($days);
     }


### PR DESCRIPTION
This PR

* [x] asserts that invalid values are rejected by `DateIntervalHelper`
* [x] rejects invalid values from `DateIntervalHelper`
* [x] throws `InvalidArgumentException`s instead of `RuntimeException`s

Follows #19.