### PR TITLE
FixtureFactory: add build() and create()

### DIFF
--- a/src/Provider/Doctrine/FixtureFactory.php
+++ b/src/Provider/Doctrine/FixtureFactory.php
@@ -76,6 +76,17 @@ class FixtureFactory
      */
     public function get($name, array $fieldOverrides = array())
     {
+        $ent = $this->build($name, $fieldOverrides);
+
+        if ($this->persist) {
+            $this->em->persist($ent);
+        }
+
+        return $ent;
+    }
+
+    public function build($name, array $fieldOverrides = array())
+    {
         if (isset($this->singletons[$name])) {
             return $this->singletons[$name];
         }
@@ -100,12 +111,19 @@ class FixtureFactory
         if (isset($config['afterCreate'])) {
             $config['afterCreate']($ent, $fieldValues);
         }
-        
-        
-        if ($this->persist) {
-            $this->em->persist($ent);
-        }
-        
+
+        return $ent;
+    }
+
+    /**
+     * Like get(), but always persists the entity
+     */
+    public function create($name, array $fieldOverrides = array())
+    {
+        $ent = $this->build($name, $fieldOverrides);
+
+        $this->em->persist($ent);
+
         return $ent;
     }
 

--- a/tests/Provider/Doctrine/Fixtures/PersistingTest.php
+++ b/tests/Provider/Doctrine/Fixtures/PersistingTest.php
@@ -27,6 +27,32 @@ class PersistingTest extends TestCase
     /**
      * @test
      */
+    public function createAlwaysPersists()
+    {
+        $ss = $this->factory->create('SpaceShip');
+        $this->em->flush();
+
+        $this->assertNotNull($ss->getId());
+        $this->assertTrue($this->em->contains($ss));
+    }
+
+    /**
+     * @test
+     */
+    public function buildNeverPersists()
+    {
+        $this->factory->persistOnGet();
+
+        $ss = $this->factory->build('SpaceShip');
+        $this->em->flush();
+
+        $this->assertNull($ss->getId());
+        $this->assertFalse($this->em->contains($ss));
+    }
+
+    /**
+     * @test
+     */
     public function doesNotPersistByDefault()
     {
         $ss = $this->factory->get('SpaceShip');

--- a/tests/Provider/Doctrine/Fixtures/PersistingTest.php
+++ b/tests/Provider/Doctrine/Fixtures/PersistingTest.php
@@ -3,30 +3,35 @@ namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures;
 
 class PersistingTest extends TestCase
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->factory->defineEntity('SpaceShip', array('name' => 'Zeta'));
+    }
+
     /**
      * @test
      */
     public function automaticPersistCanBeTurnedOn()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Zeta'));
-        
         $this->factory->persistOnGet();
+
         $ss = $this->factory->get('SpaceShip');
         $this->em->flush();
-        
+
         $this->assertNotNull($ss->getId());
         $this->assertTrue($this->em->contains($ss));
     }
-    
+
     /**
      * @test
      */
     public function doesNotPersistByDefault()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Zeta'));
         $ss = $this->factory->get('SpaceShip');
         $this->em->flush();
-        
+
         $this->assertNull($ss->getId());
         $this->assertFalse($this->em->contains($ss));
     }

--- a/tests/Provider/Doctrine/Fixtures/PersistingTest.php
+++ b/tests/Provider/Doctrine/Fixtures/PersistingTest.php
@@ -15,7 +15,7 @@ class PersistingTest extends TestCase
         $this->em->flush();
         
         $this->assertNotNull($ss->getId());
-        $this->assertEquals($ss, $this->em->find('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip', $ss->getId()));
+        $this->assertTrue($this->em->contains($ss));
     }
     
     /**
@@ -28,11 +28,6 @@ class PersistingTest extends TestCase
         $this->em->flush();
         
         $this->assertNull($ss->getId());
-        $q = $this->em
-            ->createQueryBuilder()
-            ->select('ss')
-            ->from('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip', 'ss')
-            ->getQuery();
-        $this->assertEmpty($q->getResult());
+        $this->assertFalse($this->em->contains($ss));
     }
 }


### PR DESCRIPTION
With the original Ruby factory_girl, persistence is conveniently specified on a per-call basis, by calling either `build :factory_name` (to get an un-persisted entity) or `create :factory_name` (to get a persisted one). I find it really useful and I would love to have this feature in factory-girl-php, too.

I submit this PR for initial review in order to know:

1. do you find the proposal reasonable?
2. are you OK with the refactoring I performed in `PersistingTest`?

If the proposal gets approved, I should propably add `buildList()` and `createList()` before it eventually gets merged.

Also there's the question of handling singletons properly. Does it make sense at all to `build` and `create` them, or should it only be possible to `get` them and the other two methods would throw an exception when a build or creation is attempted for a singleton?