### PR TITLE
Fix: Allow installation of doctrine/orm:~2.6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "doctrine/orm": ">=2.2.1,<2.6-dev",
+        "doctrine/orm": ">=2.2.1,<2.7-dev",
         "doctrine/dbal": ">=2.2.1,<2.7-dev",
         "doctrine/common": ">=2.2.1,<2.9-dev"
     },


### PR DESCRIPTION
This PR

* [x] adjusts the version constraints for `doctrine/orm` to allow installation of `~2.6.0`

Related to #40.