### PR TITLE
Enhancement: Add PHP 7.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS=--prefer-lowest
     - php: 7.1
+    - php: 7.2
+      env: COMPOSER_FLAGS=--prefer-lowest
+    - php: 7.2
 
 branches:
   only:


### PR DESCRIPTION
This PR

* [x] adds pHP 7.2 to the Travis CI build matrix