### PR TITLE
Fix: Do not persist embeddables

### DIFF
--- a/src/Provider/Doctrine/FixtureFactory.php
+++ b/src/Provider/Doctrine/FixtureFactory.php
@@ -4,6 +4,7 @@ namespace FactoryGirl\Provider\Doctrine;
 use Doctrine\ORM\EntityManager;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Mapping;
 use Exception;
 
 /**
@@ -84,12 +85,17 @@ class FixtureFactory
             throw EntityDefinitionUnavailable::for($name);
         }
 
+        /** @var EntityDef $def */
         $def = $this->entityDefs[$name];
+
         $config = $def->getConfig();
 
         $this->checkFieldOverrides($def, $fieldOverrides);
 
-        $ent = $def->getEntityMetadata()->newInstance();
+        /** @var Mapping\ClassMetadata $entityMetadata */
+        $entityMetadata = $def->getEntityMetadata();
+
+        $ent = $entityMetadata->newInstance();
         $fieldValues = [];
         foreach ($def->getFieldDefs() as $fieldName => $fieldDef) {
             $fieldValues[$fieldName] = array_key_exists($fieldName, $fieldOverrides)
@@ -105,7 +111,7 @@ class FixtureFactory
             $config['afterCreate']($ent, $fieldValues);
         }
 
-        if ($this->persist) {
+        if ($this->persist && false === $entityMetadata->isEmbeddedClass) {
             $this->em->persist($ent);
         }
 

--- a/tests/Provider/Doctrine/Fixtures/PersistingTest.php
+++ b/tests/Provider/Doctrine/Fixtures/PersistingTest.php
@@ -1,6 +1,9 @@
 <?php
 namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures;
 
+use FactoryGirl\Provider\Doctrine\FieldDef;
+use Doctrine\ORM\Mapping;
+
 class PersistingTest extends TestCase
 {
     /**
@@ -34,5 +37,57 @@ class PersistingTest extends TestCase
             ->from('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\SpaceShip', 'ss')
             ->getQuery();
         $this->assertEmpty($q->getResult());
+    }
+
+    /**
+     * @test
+     */
+    public function doesNotPersistEmbeddableWhenAutomaticPersistingIsTurnedOn()
+    {
+        $mappingClasses = [
+            Mapping\Embeddable::class,
+            Mapping\Embedded::class,
+        ];
+
+        foreach ($mappingClasses as $mappingClass) {
+            if (!class_exists($mappingClass)) {
+                $this->markTestSkipped('Doctrine Embeddable feature not available');
+            }
+        }
+
+        $this->factory->defineEntity('Name', [
+            'first' => FieldDef::sequence(static function () {
+                $values = [
+                    null,
+                    'Doe',
+                    'Smith',
+                ];
+
+                return $values[array_rand($values)];
+            }),
+            'last' => FieldDef::sequence(static function () {
+                $values = [
+                    null,
+                    'Jane',
+                    'John',
+                ];
+
+                return $values[array_rand($values)];
+            }),
+        ]);
+
+        $this->factory->defineEntity('Commander', [
+            'name' => FieldDef::reference('Name'),
+        ]);
+
+        $this->factory->persistOnGet();
+
+        /** @var TestEntity\Commander $commander */
+        $commander = $this->factory->get('Commander');
+
+        $this->assertInstanceOf(TestEntity\Commander::class, $commander);
+        $this->assertInstanceOf(TestEntity\Name::class, $commander->name());
+
+        $this->em->flush();
     }
 }

--- a/tests/Provider/Doctrine/Fixtures/TestEntity/Commander.php
+++ b/tests/Provider/Doctrine/Fixtures/TestEntity/Commander.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity;
+
+/**
+ * @Entity
+ */
+class Commander
+{
+    /**
+     * @Id()
+     * @GeneratedValue(strategy="AUTO")
+     * @Column(
+     *     name="id",
+     *     type="integer"
+     * )
+     *
+     * @var string
+     */
+    private $id;
+
+    /**
+     * @Embedded(
+     *     class="FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\Name",
+     *     columnPrefix=false
+     * )
+     *
+     * @var Name
+     */
+    private $name;
+
+    public function __construct()
+    {
+        $this->name = new Name();
+    }
+
+    public function id(): string
+    {
+        return $this->id;
+    }
+
+    public function name(): Name
+    {
+        return $this->name;
+    }
+}

--- a/tests/Provider/Doctrine/Fixtures/TestEntity/Name.php
+++ b/tests/Provider/Doctrine/Fixtures/TestEntity/Name.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity;
+
+/**
+ * @Embeddable
+ */
+final class Name
+{
+    /**
+     * @Column(
+     *     name="first_name",
+     *     type="string",
+     *     length=100,
+     *     nullable=true
+     * )
+     *
+     * @var string|null
+     */
+    private $first;
+
+    /**
+     * @Column(
+     *     name="last_name",
+     *     type="string",
+     *     length=100,
+     *     nullable=true
+     * )
+     *
+     * @var string|null
+     */
+    private $last;
+
+    public function first(): ?string
+    {
+        return $this->first;
+    }
+
+    public function last(): ?string
+    {
+        return $this->last;
+    }
+}


### PR DESCRIPTION
This PR

* [x] asserts that [embeddables](http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/embeddables.html) are not persisted when automated persisting is turned on
* [x] skips persisting embeddables

💁‍♂️ Not sure, but I think it would be nice if we could write definitions for embeddables as well. When turning automatic persisting on, the fixture factory attempts to persist them, though, and this will fail because they do not have an identity.