### PR TITLE
Fix: Drop support for unsupported PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,6 @@ sudo: false
 
 matrix:
   include:
-    - php: 5.4
-      env: COMPOSER_FLAGS=--prefer-lowest
-    - php: 5.4
-    - php: 5.5
-      env: COMPOSER_FLAGS=--prefer-lowest
-    - php: 5.5
-    - php: 5.6
-      env: COMPOSER_FLAGS=--prefer-lowest
-    - php: 5.6
-    - php: 7.0
-      env: COMPOSER_FLAGS=--prefer-lowest
-    - php: 7.0
     - php: 7.1
       env: COMPOSER_FLAGS=--prefer-lowest
     - php: 7.1

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "preferred-install": "dist"
     },
     "require": {
-        "php": ">=5.4.0",
+        "php": "^7.1",
         "doctrine/orm": ">=2.2.1,<3.0-dev",
         "doctrine/dbal": ">=2.2.1,<2.8-dev",
         "doctrine/common": ">=2.2.1,<2.9-dev"


### PR DESCRIPTION
This PR

* [x] drops support for unsupported PHP versions