### PR TITLE
Enhancement: Enforce coding style with friendsofphp/php-cs-fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 vendor/
+.php_cs
+.php_cs.cache
 composer.lock
 phpunit.xml

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,10 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()->in(__DIR__);
+
+return PhpCsFixer\Config::create()
+    ->setRiskyAllowed(true)
+    ->setRules([
+        '@PSR2' => true,
+    ])
+    ->setFinder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: php
 matrix:
   include:
     - php: 7.1
-      env: COMPOSER_FLAGS=--prefer-lowest
+      env: COMPOSER_FLAGS=--prefer-lowest WITH_CS=true
     - php: 7.1
     - php: 7.2
       env: COMPOSER_FLAGS=--prefer-lowest
@@ -25,4 +25,5 @@ install:
 
 script:
   - composer validate
+  - if [[ "$WITH_CS" == "true" ]]; then ./vendor/bin/php-cs-fixer fix --diff --dry-run --verbose; fi
   - ./vendor/bin/phpunit --testdox

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/orm": ">=2.2.1,<3.0-dev"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.14.0",
         "phpunit/phpunit": "4.5.0"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -44,5 +44,8 @@
         "psr-4": {
             "FactoryGirl\\Tests\\": "tests/"
         }
+    },
+    "scripts": {
+        "cs": "php-cs-fixer fix --diff --verbose"
     }
 }

--- a/tests/Provider/Doctrine/Fixtures/TimeTest.php
+++ b/tests/Provider/Doctrine/Fixtures/TimeTest.php
@@ -36,9 +36,11 @@ class TimeTest extends TestCase
         $time->add($interval);
         $this->assertEquals(
             $time->getTimestamp(),
-            FieldDef::future()->years(3)->months(1)->days(2)->get());
+            FieldDef::future()->years(3)->months(1)->days(2)->get()
+        );
         $this->assertEquals(
             $time->format('d-m-y'),
-            FieldDef::future()->years(3)->months(1)->days(2)->get(DateIntervalHelper::DATE_STRING));
+            FieldDef::future()->years(3)->months(1)->days(2)->get(DateIntervalHelper::DATE_STRING)
+        );
     }
 }

--- a/tests/Provider/Doctrine/TestDb.php
+++ b/tests/Provider/Doctrine/TestDb.php
@@ -58,8 +58,10 @@ class TestDb
      */
     public function createEntityManager()
     {
-        $em = EntityManager::create($this->connectionOptions,
-                                    $this->doctrineConfig);
+        $em = EntityManager::create(
+            $this->connectionOptions,
+                                    $this->doctrineConfig
+        );
         $this->createSchema($em);
 
         return $em;

--- a/tests/Provider/Doctrine/TestDb.php
+++ b/tests/Provider/Doctrine/TestDb.php
@@ -60,7 +60,7 @@ class TestDb
     {
         $em = EntityManager::create(
             $this->connectionOptions,
-                                    $this->doctrineConfig
+            $this->doctrineConfig
         );
         $this->createSchema($em);
 


### PR DESCRIPTION
This PR

* [x] requires `friendsofphp/php-cs-fixer`
* [x] adds a basic configuration for `friendsofphp/php-cs-fixer`
* [x] runs `php-cs-fixer` on Travis
* [x] adds a `composer` script for running `php-cs-fixer` as developer
* [x] runs `composer cs` to fix issues
* [x] manually fixes indentation for one case