### PR TITLE
Enhancement: Update phpunit/phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.14.0",
-        "phpunit/phpunit": "4.5.0"
+        "phpunit/phpunit": "^7.5.1"
     },
     "suggest": {
         "fzaninotto/faker": "For generating fake data in entity definitions"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -8,7 +8,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="tests/bootstrap.php"
 >
     <testsuites>

--- a/tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -9,9 +9,10 @@ class IncorrectUsageTest extends TestCase
     public function throwsWhenTryingToDefineTheSameEntityTwice()
     {
         $factory = $this->factory->defineEntity('SpaceShip');
-        $this->assertThrows(function () use ($factory) {
-            $factory->defineEntity('SpaceShip');
-        });
+        
+        $this->expectException(\Exception::class);
+        
+        $factory->defineEntity('SpaceShip');
     }
     
     /**
@@ -19,10 +20,9 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineEntitiesThatAreNotEvenClasses()
     {
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->defineEntity('NotAClass');
-        });
+        $this->expectException(\Exception::class);
+
+        $this->factory->defineEntity('NotAClass');
     }
     
     /**
@@ -31,11 +31,10 @@ class IncorrectUsageTest extends TestCase
     public function throwsWhenTryingToDefineEntitiesThatAreNotEntities()
     {
         $this->assertTrue(class_exists('FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity\NotAnEntity', true));
+
+        $this->expectException(\Exception::class);
         
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->defineEntity('NotAnEntity');
-        });
+        $this->factory->defineEntity('NotAnEntity');
     }
     
     /**
@@ -43,12 +42,11 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToDefineNonexistentFields()
     {
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->defineEntity('SpaceShip', array(
-                'pieType' => 'blueberry'
-            ));
-        });
+        $this->expectException(\Exception::class);
+        
+        $this->factory->defineEntity('SpaceShip', array(
+            'pieType' => 'blueberry'
+        ));
     }
     
     /**
@@ -57,13 +55,12 @@ class IncorrectUsageTest extends TestCase
     public function throwsWhenTryingToGiveNonexistentFieldsWhileConstructing()
     {
         $this->factory->defineEntity('SpaceShip', array('name' => 'Alpha'));
-        
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->get('SpaceShip', array(
-                'pieType' => 'blueberry'
-            ));
-        });
+
+        $this->expectException(\Exception::class);
+
+        $this->factory->get('SpaceShip', array(
+            'pieType' => 'blueberry'
+        ));
     }
 
     /**
@@ -73,9 +70,8 @@ class IncorrectUsageTest extends TestCase
     {
         $this->factory->defineEntity('SpaceShip');
 
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->getList('SpaceShip', array(), 0);
-        });
+        $this->expectException(\Exception::class);
+
+        $this->factory->getList('SpaceShip', array(), 0);
     }
 }

--- a/tests/Provider/Doctrine/Fixtures/SingletonTest.php
+++ b/tests/Provider/Doctrine/Fixtures/SingletonTest.php
@@ -35,11 +35,10 @@ class SingletonTest extends TestCase
     {
         $this->factory->defineEntity('SpaceShip', array('name' => 'Alpha'));
         $this->factory->getAsSingleton('SpaceShip');
-        
-        $self = $this;
-        $this->assertThrows(function () use ($self) {
-            $self->factory->getAsSingleton('SpaceShip');
-        });
+
+        $this->expectException(\Exception::class);
+
+        $this->factory->getAsSingleton('SpaceShip');
     }
     
     //TODO: should it be an error to get() a singleton with overrides?

--- a/tests/Provider/Doctrine/Fixtures/TestCase.php
+++ b/tests/Provider/Doctrine/Fixtures/TestCase.php
@@ -2,14 +2,13 @@
 
 namespace FactoryGirl\Tests\Provider\Doctrine\Fixtures;
 
-use PHPUnit_Framework_TestCase;
-use PHPUnit_Framework_Error;
+use PHPUnit\Framework;
 use FactoryGirl\Tests\Provider\Doctrine\TestDb;
 use FactoryGirl\Provider\Doctrine\FixtureFactory;
 use Doctrine\ORM\EntityManager;
 use Exception;
 
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends Framework\TestCase
 {
     /**
      * @var TestDb
@@ -58,7 +57,7 @@ abstract class TestCase extends PHPUnit_Framework_TestCase
         if (!isset($e)) {
             $this->fail("Expected $exceptionType but nothing was thrown");
         }
-        if ($e instanceof PHPUnit_Framework_Error) {
+        if ($e instanceof Framework\Error\Error) {
             $this->fail('Expected exception but got a PHP error: ' . $e->getMessage());
         }
         if (!($e instanceof $exceptionType)) {

--- a/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
+++ b/tests/Provider/Doctrine/ORM/DateIntervalHelperTest.php
@@ -3,8 +3,9 @@
 namespace FactoryGirl\Tests\Provider\Doctrine\ORM;
 
 use FactoryGirl\Provider\Doctrine\DateIntervalHelper;
+use PHPUnit\Framework;
 
-class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
+class DateIntervalHelperTest extends Framework\TestCase
 {
     /**
      * @dataProvider providerInvalidIntegerish
@@ -15,7 +16,8 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('InvalidArgumentException', sprintf(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
             'Expected integer or integerish string, got "%s" instead.',
             is_object($years) ? get_class($years) : gettype($years)
         ));
@@ -32,7 +34,8 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('InvalidArgumentException', sprintf(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
             'Expected integer or integerish string, got "%s" instead.',
             is_object($months) ? get_class($months) : gettype($months)
         ));
@@ -49,7 +52,8 @@ class DateIntervalHelperTest extends \PHPUnit_Framework_TestCase
     {
         $helper = new DateIntervalHelper(new \DateTime());
         
-        $this->setExpectedException('InvalidArgumentException', sprintf(
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage(sprintf(
             'Expected integer or integerish string, got "%s" instead.',
             is_object($days) ? get_class($days) : gettype($days)
         ));

--- a/tests/Provider/Doctrine/ORM/TestCase.php
+++ b/tests/Provider/Doctrine/ORM/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace FactoryGirl\Tests\Provider\Doctrine\ORM;
 
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework;
 use FactoryGirl\Tests\Provider\Doctrine\TestDb;
 
 /**
@@ -12,7 +12,7 @@ use FactoryGirl\Tests\Provider\Doctrine\TestDb;
  * @author     Mikko Hirvonen <mikko.petteri.hirvonen@gmail.com>
  * @license    http://www.opensource.org/licenses/BSD-3-Clause New BSD License
  */
-abstract class TestCase extends PHPUnit_Framework_TestCase
+abstract class TestCase extends Framework\TestCase
 {
     /**
      * @var TestDb

--- a/tests/Provider/Doctrine/Types/StatusArrayTest.php
+++ b/tests/Provider/Doctrine/Types/StatusArrayTest.php
@@ -4,6 +4,7 @@ namespace FactoryGirl\Tests\Provider\Doctrine\Types;
 
 use FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestCase;
 use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\ConversionException;
 
 Type::addType('statusarray', 'FactoryGirl\Provider\Doctrine\DBAL\Types\StatusArrayType');
 
@@ -43,10 +44,11 @@ class StatusArrayTest extends TestCase
     
     /**
      * @test
-     * @expectedException Doctrine\DBAL\Types\ConversionException
      */
     public function nonArrayOrNotNullShouldFailDatabaseConversion()
     {
+        $this->expectException(ConversionException::class);
+
         $value = 'lussenhof';
         $this->type->convertToDatabaseValue($value, $this->platform);
     }
@@ -79,11 +81,12 @@ class StatusArrayTest extends TestCase
     
     /**
      * @test
-     * @expectedException Doctrine\DBAL\Types\ConversionException
      * @dataProvider provideStupidValues
      */
     public function invalidCharactersShouldFailDatabaseConversion($stupidValue)
     {
+        $this->expectException(ConversionException::class);
+
         $value = array($stupidValue);
         $this->type->convertToDatabaseValue($value, $this->platform);
     }


### PR DESCRIPTION
This PR

* [x] updates `phpunit/phpunit`
* [x] renames an abstract test case
* [x] applies `@PHPUnit60Migration:risky` ruleset of `friendsofphp/php-cs-fixer`
* [x] removes an invalid attribute `syntaxCheck` from `phpunit.xml`
* [x] uses test framework facilities for expecting exceptions

Blocks #47.