### PR TITLE
Enhancement: Enable php_unit_set_up_tear_down_visibility fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,5 +6,6 @@ return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
+        'php_unit_set_up_tear_down_visibility' => true,
     ])
     ->setFinder($finder);

--- a/tests/Provider/Doctrine/Fixtures/ReferenceTest.php
+++ b/tests/Provider/Doctrine/Fixtures/ReferenceTest.php
@@ -5,7 +5,7 @@ use FactoryGirl\Provider\Doctrine\FieldDef;
 
 class ReferenceTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
         

--- a/tests/Provider/Doctrine/Fixtures/ReferencesTest.php
+++ b/tests/Provider/Doctrine/Fixtures/ReferencesTest.php
@@ -7,7 +7,7 @@ use FactoryGirl\Tests\Provider\Doctrine\Fixtures\TestEntity;
 
 class ReferencesTest extends TestCase
 {
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Provider/Doctrine/Fixtures/TestCase.php
+++ b/tests/Provider/Doctrine/Fixtures/TestCase.php
@@ -27,7 +27,7 @@ abstract class TestCase extends Framework\TestCase
      */
     public $factory;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Provider/Doctrine/ORM/RepositoryTest.php
+++ b/tests/Provider/Doctrine/ORM/RepositoryTest.php
@@ -19,7 +19,7 @@ class RepositoryTest extends TestCase
      */
     private $repository;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Provider/Doctrine/ORM/TestCase.php
+++ b/tests/Provider/Doctrine/ORM/TestCase.php
@@ -24,7 +24,7 @@ abstract class TestCase extends Framework\TestCase
      */
     protected $em;
 
-    public function setUp()
+    protected function setUp()
     {
         parent::setUp();
 

--- a/tests/Provider/Doctrine/Types/StatusArrayTest.php
+++ b/tests/Provider/Doctrine/Types/StatusArrayTest.php
@@ -17,7 +17,7 @@ class StatusArrayTest extends TestCase
      */
     protected $type;
 
-    public function setUp()
+    protected function setUp()
     {
         $this->platform = $this->getMockForAbstractClass('\Doctrine\DBAL\Platforms\AbstractPlatform');
         $this->type = Type::getType('statusarray');


### PR DESCRIPTION
This PR

* [x] enables the `php_unit_set_up_tear_down_visibility` fixer
* [x] runs `composer cs`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.13.1#usage:

>**php_unit_set_up_tear_down_visibility**
>
>Changes the visibility of the `setUp()` and `tearDown()` functions of PHPUnit to `protected`, to match the PHPUnit TestCase.
>
>*Risky rule: this fixer may change functions named ``setUp()`` or ``tearDown()`` outside of PHPUnit tests, when a class is wrongly seen as a PHPUnit test.*