### PR TITLE
Enhancement: Enable and configure array_syntax fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -6,6 +6,9 @@ return PhpCsFixer\Config::create()
     ->setRiskyAllowed(true)
     ->setRules([
         '@PSR2' => true,
+        'array_syntax' => [
+            'syntax' => 'short',
+        ],
         'php_unit_set_up_tear_down_visibility' => true,
     ])
     ->setFinder($finder);

--- a/src/Provider/Doctrine/EntityDef.php
+++ b/src/Provider/Doctrine/EntityDef.php
@@ -28,7 +28,7 @@ class EntityDef
         $this->name = $name;
         $this->entityType = $type;
         $this->metadata = $em->getClassMetadata($type);
-        $this->fieldDefs = array();
+        $this->fieldDefs = [];
         $this->config = $config;
         
         $this->readFieldDefs($fieldDefs);

--- a/src/Provider/Doctrine/FixtureFactory.php
+++ b/src/Provider/Doctrine/FixtureFactory.php
@@ -45,9 +45,9 @@ class FixtureFactory
         
         $this->entityNamespace = '';
         
-        $this->entityDefs = array();
+        $this->entityDefs = [];
         
-        $this->singletons = array();
+        $this->singletons = [];
         
         $this->persist = false;
     }
@@ -74,7 +74,7 @@ class FixtureFactory
      *
      * If you've called `persistOnGet()` then the entity is also persisted.
      */
-    public function get($name, array $fieldOverrides = array())
+    public function get($name, array $fieldOverrides = [])
     {
         if (isset($this->singletons[$name])) {
             return $this->singletons[$name];
@@ -86,7 +86,7 @@ class FixtureFactory
         $this->checkFieldOverrides($def, $fieldOverrides);
         
         $ent = $def->getEntityMetadata()->newInstance();
-        $fieldValues = array();
+        $fieldValues = [];
         foreach ($def->getFieldDefs() as $fieldName => $fieldDef) {
             $fieldValues[$fieldName] = array_key_exists($fieldName, $fieldOverrides)
                 ? $fieldOverrides[$fieldName]
@@ -118,7 +118,7 @@ class FixtureFactory
      *
      * If you've called `persistOnGet()` then the entities are also persisted.
      */
-    public function getList($name, array $fieldOverrides = array(), $numberOfInstances = 1)
+    public function getList($name, array $fieldOverrides = [], $numberOfInstances = 1)
     {
         if ($numberOfInstances < 1) {
             throw new \InvalidArgumentException('Can only get >= 1 instances');
@@ -128,7 +128,7 @@ class FixtureFactory
             $numberOfInstances = 1;
         }
 
-        $instances = array();
+        $instances = [];
         for ($i = 0; $i < $numberOfInstances; $i++) {
             $instances[] = $this->get($name, $fieldOverrides);
         }
@@ -159,7 +159,7 @@ class FixtureFactory
         }
     }
 
-    protected function createCollectionFrom($array = array())
+    protected function createCollectionFrom($array = [])
     {
         if (is_array($array)) {
             return new ArrayCollection($array);
@@ -183,7 +183,7 @@ class FixtureFactory
      *
      * It's illegal to call this if `$name` already has a singleton.
      */
-    public function getAsSingleton($name, array $fieldOverrides = array())
+    public function getAsSingleton($name, array $fieldOverrides = [])
     {
         if (isset($this->singletons[$name])) {
             throw new Exception("Already a singleton: $name");
@@ -219,7 +219,7 @@ class FixtureFactory
      *
      * @return FixtureFactory
      */
-    public function defineEntity($name, array $fieldDefs = array(), array $config = array())
+    public function defineEntity($name, array $fieldDefs = [], array $config = [])
     {
         if (isset($this->entityDefs[$name])) {
             throw new Exception("Entity '$name' already defined in fixture factory");

--- a/src/Provider/Doctrine/ORM/Locking/TableLock.php
+++ b/src/Provider/Doctrine/ORM/Locking/TableLock.php
@@ -120,12 +120,12 @@ class TableLock
      */
     private function getTableAliasGuesstimates($tableName)
     {
-        return array_unique(array(
+        return array_unique([
             // the default generated alias: the first letter of the table name prepended with a zero
             strtolower(substr($tableName, 0, 1)) . '0',
             // a generic alias used by Doctrine in many cases
             't0'
-        ));
+        ]);
     }
     
     /**

--- a/src/Provider/Doctrine/ORM/QueryBuilder.php
+++ b/src/Provider/Doctrine/ORM/QueryBuilder.php
@@ -13,12 +13,12 @@ class QueryBuilder extends DoctrineQueryBuilder
     /**
      * @var array<string => boolean>
      */
-    protected $_statuses = array();
+    protected $_statuses = [];
     
     /**
      * @var array<callback(Query)>
      */
-    protected $_queryConfigurers = array();
+    protected $_queryConfigurers = [];
     
     /**
      * Entity name associated with this query builder (if any)

--- a/tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
+++ b/tests/Provider/Doctrine/Fixtures/BasicUsageTest.php
@@ -12,9 +12,9 @@ class BasicUsageTest extends TestCase
     public function acceptsConstantValuesInEntityDefinitions()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', array(
+            ->defineEntity('SpaceShip', [
                 'name' => 'My BattleCruiser'
-            ))
+            ])
             ->get('SpaceShip');
         
         $this->assertSame('My BattleCruiser', $ss->getName());
@@ -26,11 +26,11 @@ class BasicUsageTest extends TestCase
     public function acceptsGeneratorFunctionsInEntityDefinitions()
     {
         $name = "Star";
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => function () use (&$name) {
                 return "M/S $name";
             }
-        ));
+        ]);
         
         $this->assertSame('M/S Star', $this->factory->get('SpaceShip')->getName());
         $name = "Superstar";
@@ -43,10 +43,10 @@ class BasicUsageTest extends TestCase
     public function valuesCanBeOverriddenAtCreationTime()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', array(
+            ->defineEntity('SpaceShip', [
                 'name' => 'My BattleCruiser'
-            ))
-            ->get('SpaceShip', array('name' => 'My CattleBruiser'));
+            ])
+            ->get('SpaceShip', ['name' => 'My CattleBruiser']);
         $this->assertSame('My CattleBruiser', $ss->getName());
     }
 
@@ -67,7 +67,7 @@ class BasicUsageTest extends TestCase
     public function doesNotCallTheConstructorOfTheEntity()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', array())
+            ->defineEntity('SpaceShip', [])
             ->get('SpaceShip');
         $this->assertFalse($ss->constructorWasCalled());
     }
@@ -78,9 +78,9 @@ class BasicUsageTest extends TestCase
     public function instantiatesCollectionAssociationsToBeEmptyCollectionsWhenUnspecified()
     {
         $ss = $this->factory
-            ->defineEntity('SpaceShip', array(
+            ->defineEntity('SpaceShip', [
                 'name' => 'Battlestar Galaxy'
-            ))
+            ])
             ->get('SpaceShip');
         
         $this->assertInstanceOf(ArrayCollection::class, $ss->getCrew());
@@ -93,17 +93,17 @@ class BasicUsageTest extends TestCase
     public function arrayElementsAreMappedToCollectionAsscociationFields()
     {
         $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'spaceShip' => FieldDef::reference('SpaceShip')
-        ));
+        ]);
 
         $p1 = $this->factory->get('Person');
         $p2 = $this->factory->get('Person');
 
-        $ship = $this->factory->get('SpaceShip', array(
+        $ship = $this->factory->get('SpaceShip', [
             'name' => 'Battlestar Galaxy',
-            'crew' => array($p1, $p2)
-        ));
+            'crew' => [$p1, $p2]
+        ]);
         
         $this->assertInstanceOf(ArrayCollection::class, $ship->getCrew());
         $this->assertTrue($ship->getCrew()->contains($p1));
@@ -172,6 +172,6 @@ class BasicUsageTest extends TestCase
     {
         $this->factory->defineEntity('SpaceShip');
 
-        $this->assertCount(5, $this->factory->getList('SpaceShip', array(), 5));
+        $this->assertCount(5, $this->factory->getList('SpaceShip', [], 5));
     }
 }

--- a/tests/Provider/Doctrine/Fixtures/BidirectionalReferencesTest.php
+++ b/tests/Provider/Doctrine/Fixtures/BidirectionalReferencesTest.php
@@ -11,9 +11,9 @@ class BidirectionalReferencesTest extends TestCase
     public function bidirectionalOntToManyReferencesAreAssignedBothWays()
     {
         $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'spaceShip' => FieldDef::reference('SpaceShip')
-        ));
+        ]);
         
         $person = $this->factory->get('Person');
         $ship = $person->getSpaceShip();
@@ -26,9 +26,9 @@ class BidirectionalReferencesTest extends TestCase
      */
     public function unidirectionalReferencesWorkAsUsual()
     {
-        $this->factory->defineEntity('Badge', array(
+        $this->factory->defineEntity('Badge', [
             'owner' => FieldDef::reference('Person')
-        ));
+        ]);
         $this->factory->defineEntity('Person');
         
         $this->assertInstanceOf(TestEntity\Person::class, $this->factory->get('Badge')->getOwner());
@@ -40,9 +40,9 @@ class BidirectionalReferencesTest extends TestCase
     public function whenTheOneSideIsASingletonItMayGetSeveralChildObjects()
     {
         $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'spaceShip' => FieldDef::reference('SpaceShip')
-        ));
+        ]);
         
         $ship = $this->factory->getAsSingleton('SpaceShip');
         $p1 = $this->factory->get('Person');

--- a/tests/Provider/Doctrine/Fixtures/ExtraConfigurationTest.php
+++ b/tests/Provider/Doctrine/Fixtures/ExtraConfigurationTest.php
@@ -8,13 +8,13 @@ class ExtraConfigurationTest extends TestCase
      */
     public function canInvokeACallbackAfterObjectConstruction()
     {
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => 'Foo'
-        ), array(
+        ], [
             'afterCreate' => function (TestEntity\SpaceShip $ss, array $fieldValues) {
                 $ss->setName($ss->getName() . '-' . $fieldValues['name']);
             }
-        ));
+        ]);
         $ss = $this->factory->get('SpaceShip');
         
         $this->assertSame("Foo-Foo", $ss->getName());
@@ -25,14 +25,14 @@ class ExtraConfigurationTest extends TestCase
      */
     public function theAfterCreateCallbackCanBeUsedToCallTheConstructor()
     {
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => 'Foo'
-        ), array(
+        ], [
             'afterCreate' => function (TestEntity\SpaceShip $ss, array $fieldValues) {
                 $ss->__construct($fieldValues['name'] . 'Master');
             }
-        ));
-        $ss = $this->factory->get('SpaceShip', array('name' => 'Xoo'));
+        ]);
+        $ss = $this->factory->get('SpaceShip', ['name' => 'Xoo']);
         
         $this->assertTrue($ss->constructorWasCalled());
         $this->assertSame('XooMaster', $ss->getName());

--- a/tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
+++ b/tests/Provider/Doctrine/Fixtures/IncorrectUsageTest.php
@@ -44,9 +44,9 @@ class IncorrectUsageTest extends TestCase
     {
         $this->expectException(\Exception::class);
         
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'pieType' => 'blueberry'
-        ));
+        ]);
     }
     
     /**
@@ -54,13 +54,13 @@ class IncorrectUsageTest extends TestCase
      */
     public function throwsWhenTryingToGiveNonexistentFieldsWhileConstructing()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Alpha'));
+        $this->factory->defineEntity('SpaceShip', ['name' => 'Alpha']);
 
         $this->expectException(\Exception::class);
 
-        $this->factory->get('SpaceShip', array(
+        $this->factory->get('SpaceShip', [
             'pieType' => 'blueberry'
-        ));
+        ]);
     }
 
     /**
@@ -72,6 +72,6 @@ class IncorrectUsageTest extends TestCase
 
         $this->expectException(\Exception::class);
 
-        $this->factory->getList('SpaceShip', array(), 0);
+        $this->factory->getList('SpaceShip', [], 0);
     }
 }

--- a/tests/Provider/Doctrine/Fixtures/PersistingTest.php
+++ b/tests/Provider/Doctrine/Fixtures/PersistingTest.php
@@ -8,7 +8,7 @@ class PersistingTest extends TestCase
      */
     public function automaticPersistCanBeTurnedOn()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Zeta'));
+        $this->factory->defineEntity('SpaceShip', ['name' => 'Zeta']);
         
         $this->factory->persistOnGet();
         $ss = $this->factory->get('SpaceShip');
@@ -23,7 +23,7 @@ class PersistingTest extends TestCase
      */
     public function doesNotPersistByDefault()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Zeta'));
+        $this->factory->defineEntity('SpaceShip', ['name' => 'Zeta']);
         $ss = $this->factory->get('SpaceShip');
         $this->em->flush();
         

--- a/tests/Provider/Doctrine/Fixtures/ReferenceTest.php
+++ b/tests/Provider/Doctrine/Fixtures/ReferenceTest.php
@@ -10,10 +10,10 @@ class ReferenceTest extends TestCase
         parent::setUp();
         
         $this->factory->defineEntity('SpaceShip');
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'name' => 'Eve',
             'spaceShip' => FieldDef::reference('SpaceShip')
-        ));
+        ]);
     }
     
     /**
@@ -34,7 +34,7 @@ class ReferenceTest extends TestCase
      */
     public function referencedObjectsShouldBeNullable()
     {
-        $person = $this->factory->get('Person', array('spaceShip' => null));
+        $person = $this->factory->get('Person', ['spaceShip' => null]);
         
         $this->assertNull($person->getSpaceShip());
     }

--- a/tests/Provider/Doctrine/Fixtures/ReferencesTest.php
+++ b/tests/Provider/Doctrine/Fixtures/ReferencesTest.php
@@ -11,13 +11,13 @@ class ReferencesTest extends TestCase
     {
         parent::setUp();
 
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'crew' => FieldDef::references('Person')
-        ));
+        ]);
 
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'name' => 'Eve',
-        ));
+        ]);
     }
 
     /**
@@ -43,9 +43,9 @@ class ReferencesTest extends TestCase
         $count = 5;
 
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip', array(
-            'crew' => $this->factory->getList('Person', array(), $count),
-        ));
+        $spaceShip = $this->factory->get('SpaceShip', [
+            'crew' => $this->factory->getList('Person', [], $count),
+        ]);
 
         $crew = $spaceShip->getCrew();
 
@@ -60,9 +60,9 @@ class ReferencesTest extends TestCase
     public function referencedObjectsShouldBeNullable()
     {
         /** @var TestEntity\SpaceShip $spaceShip */
-        $spaceShip = $this->factory->get('SpaceShip', array(
+        $spaceShip = $this->factory->get('SpaceShip', [
             'crew' => null,
-        ));
+        ]);
 
         $crew = $spaceShip->getCrew();
 

--- a/tests/Provider/Doctrine/Fixtures/SequenceTest.php
+++ b/tests/Provider/Doctrine/Fixtures/SequenceTest.php
@@ -11,11 +11,11 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCallsAFunctionWithAnIncrementingArgument()
     {
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => FieldDef::sequence(function ($n) {
                 return "Alpha $n";
             })
-        ));
+        ]);
         $this->assertSame('Alpha 1', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Alpha 2', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Alpha 3', $this->factory->get('SpaceShip')->getName());
@@ -27,9 +27,9 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAPlaceholderString()
     {
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => FieldDef::sequence("Beta %d")
-        ));
+        ]);
         $this->assertSame('Beta 1', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Beta 2', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Beta 3', $this->factory->get('SpaceShip')->getName());
@@ -41,9 +41,9 @@ class SequenceTest extends TestCase
      */
     public function sequenceGeneratorCanTakeAStringToAppendTo()
     {
-        $this->factory->defineEntity('SpaceShip', array(
+        $this->factory->defineEntity('SpaceShip', [
             'name' => FieldDef::sequence("Gamma ")
-        ));
+        ]);
         $this->assertSame('Gamma 1', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Gamma 2', $this->factory->get('SpaceShip')->getName());
         $this->assertSame('Gamma 3', $this->factory->get('SpaceShip')->getName());

--- a/tests/Provider/Doctrine/Fixtures/SingletonTest.php
+++ b/tests/Provider/Doctrine/Fixtures/SingletonTest.php
@@ -23,7 +23,7 @@ class SingletonTest extends TestCase
     {
         $this->factory->defineEntity('SpaceShip');
         
-        $ss = $this->factory->getAsSingleton('SpaceShip', array('name' => 'Beta'));
+        $ss = $this->factory->getAsSingleton('SpaceShip', ['name' => 'Beta']);
         $this->assertSame('Beta', $ss->getName());
         $this->assertSame('Beta', $this->factory->get('SpaceShip')->getName());
     }
@@ -33,7 +33,7 @@ class SingletonTest extends TestCase
      */
     public function throwsAnErrorWhenCallingGetSingletonTwiceOnTheSameEntity()
     {
-        $this->factory->defineEntity('SpaceShip', array('name' => 'Alpha'));
+        $this->factory->defineEntity('SpaceShip', ['name' => 'Alpha']);
         $this->factory->getAsSingleton('SpaceShip');
 
         $this->expectException(\Exception::class);

--- a/tests/Provider/Doctrine/Fixtures/TransitiveReferencesTest.php
+++ b/tests/Provider/Doctrine/Fixtures/TransitiveReferencesTest.php
@@ -8,12 +8,12 @@ class TransitiveReferencesTest extends TestCase
 {
     private function simpleSetup()
     {
-        $this->factory->defineEntity('Person', array(
+        $this->factory->defineEntity('Person', [
             'spaceShip' => FieldDef::reference('SpaceShip'),
-        ));
-        $this->factory->defineEntity('Badge', array(
+        ]);
+        $this->factory->defineEntity('Badge', [
             'owner' => FieldDef::reference('Person')
-        ));
+        ]);
         $this->factory->defineEntity('SpaceShip');
     }
     

--- a/tests/Provider/Doctrine/TestDb.php
+++ b/tests/Provider/Doctrine/TestDb.php
@@ -45,10 +45,10 @@ class TestDb
         $config->setProxyNamespace($proxyNamespace);
         $config->setAutoGenerateProxyClasses(true);
 
-        $this->connectionOptions = array(
+        $this->connectionOptions = [
             'driver' => 'pdo_sqlite',
             'path'   => ':memory:'
-        );
+        ];
 
         $this->doctrineConfig = $config;
     }

--- a/tests/Provider/Doctrine/Types/StatusArrayTest.php
+++ b/tests/Provider/Doctrine/Types/StatusArrayTest.php
@@ -56,26 +56,26 @@ class StatusArrayTest extends TestCase
     
     public function provideStupidValues()
     {
-        return array(
-            array('//'),
-            array('###'),
-            array('lussenhofen%meister'),
-        );
+        return [
+            ['//'],
+            ['###'],
+            ['lussenhofen%meister'],
+        ];
     }
     
     
     public function provideAcceptableValues()
     {
-        return array(
-            array(
+        return [
+            [
                 '[lussen.hofer];[lussen:meister];[1];[563]',
-                array('lussen.hofer', 'lussen:meister', 1, 563),
-            ),
-            array(
+                ['lussen.hofer', 'lussen:meister', 1, 563],
+            ],
+            [
                 '[lussen.hofer]',
-                array('lussen.hofer'),
-            ),
-        );
+                ['lussen.hofer'],
+            ],
+        ];
     }
     
     
@@ -87,7 +87,7 @@ class StatusArrayTest extends TestCase
     {
         $this->expectException(ConversionException::class);
 
-        $value = array($stupidValue);
+        $value = [$stupidValue];
         $this->type->convertToDatabaseValue($value, $this->platform);
     }
     
@@ -105,12 +105,12 @@ class StatusArrayTest extends TestCase
     
     public function provideSerializedValues()
     {
-        return array(
-            array(
-                array('lussen', 'hofer', '645', 'meisten:lusdre', 'larva.lussutab.tussi'),
+        return [
+            [
+                ['lussen', 'hofer', '645', 'meisten:lusdre', 'larva.lussutab.tussi'],
                 '[lussen];[hofer];[645];[meisten:lusdre];[larva.lussutab.tussi]',
-            )
-        );
+            ]
+        ];
     }
     
     


### PR DESCRIPTION
This PR

* [x] enables and configures the `array_syntax` fixer
* [x] runs `composer cs`

Follows #52.

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v2.14.0#usage:

>**array_syntax** [`@PhpCsFixer`]
>
>PHP arrays should be declared using the configured syntax.
>
>Configuration options:
>
>* `syntax` (`'long'`, `'short'`): whether to use the long or short array syntax; defaults to `'long'`